### PR TITLE
Fix gradientDescent softmax derivative

### DIFF
--- a/gradientDescent.py
+++ b/gradientDescent.py
@@ -121,7 +121,8 @@ def softmax_cross_entropy_loss_der(Y, A):
     labels[np.arange(m), Y.astype(int)] = 1
     labels = labels.T #(n,m) (10, 6000)
 
-    m = np.shape(Y)[0]
+    # number of training examples
+    m = A.shape[1]
     dZ = A - labels
     dZ = dZ / m
     ###


### PR DESCRIPTION
## Summary
- fix division term in softmax derivative for proper scaling

## Testing
- `python3 -m py_compile gradientDescent.py`
- `python3 -m py_compile load_fashion_mnist.py`
- `python3 -m py_compile CNN.py SVM.py Linear_Regression_Implementation.py Sex-ratio.py`


------
https://chatgpt.com/codex/tasks/task_e_68460789ca0c83228e1cf910ee1f8a08